### PR TITLE
[PPWP-32] - Migrar helpers do Woocommerce para Prestashop

### DIFF
--- a/includes/helpers/cryptography/class-cryptography.php
+++ b/includes/helpers/cryptography/class-cryptography.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * 2007-2021 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2021 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ *
+ * Don't forget to prefix your containers with your own identifier
+ * to avoid any conflicts with others containers.
+ */
+
+/**
+ * Class Cryptography
+ */
+class Cryptography {
+
+	/**
+	 * Object to String
+	 * @param array $array
+	 * @return String
+	 */
+	public static function obj_to_string( $array ) {
+
+		ksort($array);
+
+		$data = '';
+
+		foreach ($array as $key=>$value) {
+			$data .= $key . '=' . $value . '&';
+		}
+
+		$data = substr( $data, 0, -1 );
+
+		return $data;
+	}
+
+	/**
+	 * Verify token
+	 * @param String $key
+	 * @param String $hmac
+	 * @return Boolean
+	 */
+	public static function verify( $key, $hmac ) {
+		if (hash_equals($key, $hmac)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Encrypt
+	 * @param array $data
+	 * @param String $secret
+	 * @return String
+	 */
+	public static function encrypt( $data, $secret ) {
+		if (!empty($secret) && !empty($data)) {
+			try {
+				$string = self::obj_to_string($data);
+				$hmac   = hash_hmac('sha256', $string, $secret, true);
+				$key    = base64_encode($hmac);// phpcs:ignore
+				return $key;
+			} catch (Exception $e) {
+				$message =  "Error while encrypting. <br> $e";
+				return $message;
+			}
+		} else {
+			throw new Exception('Empty parameters');
+		}
+	}
+
+	
+}

--- a/includes/helpers/cryptography/class-cryptography.php
+++ b/includes/helpers/cryptography/class-cryptography.php
@@ -77,7 +77,7 @@ class Cryptography {
 			try {
 				$string = self::obj_to_string($data);
 				$hmac   = hash_hmac('sha256', $string, $secret, true);
-				$key    = base64_encode($hmac);// phpcs:ignore
+				$key    = base64_encode($hmac);
 				return $key;
 			} catch (Exception $e) {
 				$message =  "Error while encrypting. <br> $e";

--- a/includes/helpers/cryptography/class-cryptography.php
+++ b/includes/helpers/cryptography/class-cryptography.php
@@ -80,8 +80,7 @@ class Cryptography {
 				$key    = base64_encode($hmac);
 				return $key;
 			} catch (Exception $e) {
-				$message =  "Error while encrypting. <br> $e";
-				return $message;
+				throw new Exception($e);
 			}
 		} else {
 			throw new Exception('Empty parameters');

--- a/includes/helpers/cryptography/index.php
+++ b/includes/helpers/cryptography/index.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* 2007-2021 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2021 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/includes/helpers/index.php
+++ b/includes/helpers/index.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* 2007-2021 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2021 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/includes/helpers/resquest/class-resquest.php
+++ b/includes/helpers/resquest/class-resquest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * 2007-2021 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2021 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ *
+ * Don't forget to prefix your containers with your own identifier
+ * to avoid any conflicts with others containers.
+ */
+
+/**
+ * Class Request
+ */
+class Request {
+	/**
+	 * Get header Authorization
+	 */
+	public static function getAuthorizationHeader() {
+		$headers = null;
+		if (isset($_SERVER['Authorization'])) {
+			// @todo need fix Processing form data without nonce verification
+			// @codingStandardsIgnoreLine
+			$headers = trim($_SERVER['Authorization']);
+		} elseif ( isset($_SERVER['HTTP_AUTHORIZATION']) ) {
+			// @todo need fix Processing form data without nonce verification
+			// @codingStandardsIgnoreLine
+			$headers = trim($_SERVER['HTTP_AUTHORIZATION']);
+		} elseif (function_exists('apache_request_headers')) {
+			$requestHeaders = apache_request_headers();
+			// Server-side fix for bug in old Android versions (a nice side-effect of this fix means we don't care about capitalization for Authorization)
+			$requestHeaders = array_combine(array_map('ucwords', array_keys($requestHeaders)), array_values($requestHeaders));
+			if (isset($requestHeaders['Authorization'])) {
+				$headers = trim($requestHeaders['Authorization']);
+			}
+		}
+		return $headers;
+	}
+
+	/**
+	 * Get access token from header
+	 */
+	public static function getBearerToken() {
+		$headers = self::getAuthorizationHeader();
+
+		// HEADER: Get the access token from the header
+		if (!empty($headers)) {
+			if (preg_match('/Bearer\s(\S+)/', $headers, $matches)) {
+				return $matches[1];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get json body
+	 */
+	public static function getJsonBody() {
+		$post = file_get_contents('php://input');
+		$post = (array) json_decode($post);
+
+		if ( isset($post) && !empty($post) ) {
+			return $post;
+		}
+
+		return null;
+	}
+}

--- a/includes/helpers/resquest/class-resquest.php
+++ b/includes/helpers/resquest/class-resquest.php
@@ -37,12 +37,8 @@ class Request {
 	public static function getAuthorizationHeader() {
 		$headers = null;
 		if (isset($_SERVER['Authorization'])) {
-			// @todo need fix Processing form data without nonce verification
-			// @codingStandardsIgnoreLine
 			$headers = trim($_SERVER['Authorization']);
 		} elseif ( isset($_SERVER['HTTP_AUTHORIZATION']) ) {
-			// @todo need fix Processing form data without nonce verification
-			// @codingStandardsIgnoreLine
 			$headers = trim($_SERVER['HTTP_AUTHORIZATION']);
 		} elseif (function_exists('apache_request_headers')) {
 			$requestHeaders = apache_request_headers();

--- a/includes/helpers/resquest/index.php
+++ b/includes/helpers/resquest/index.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* 2007-2021 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2021 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;


### PR DESCRIPTION
Trazendo algumas funcionalidades utilizadas no Woocommerce. Algumas não precisaram ser importadas pois o Prestashop já tinha uma boa base de código. O que não foi migrado foi a parte de logs e nem a de credenciais. 