### PR TITLE
[Extra-mile][Prestashop] Remover pix e meli-places como formas de pagamento no checkout

### DIFF
--- a/includes/module/checkouts/StandardCheckout.php
+++ b/includes/module/checkouts/StandardCheckout.php
@@ -29,6 +29,10 @@
 
 class StandardCheckout
 {
+    const METHOD_CREDIT_CARD = 1;
+    const METHOD_DEBIT_CARD = 2;
+    const METHOD_TICKET = 3;
+
     /**
      * @var Mercadopago
      */
@@ -83,11 +87,13 @@ class StandardCheckout
         foreach ($tarjetas as $tarjeta) {
             if (Configuration::get($tarjeta['config']) != "") {
                 $count++;
-                if ($tarjeta['type'] == 'credit_card') {
+                if ($this->paymentMethodsCheck($tarjeta) === self::METHOD_CREDIT_CARD) {
                     $credit[] = $tarjeta;
-                } elseif ($tarjeta['type'] == 'debit_card' || $tarjeta['type'] == 'prepaid_card') {
+                } 
+                if ($this->paymentMethodsCheck($tarjeta) === self::METHOD_DEBIT_CARD) {
                     $debit[] = $tarjeta;
-                } else {
+                } 
+                if ($this->paymentMethodsCheck($tarjeta) === self::METHOD_TICKET) {
                     $ticket[] = $tarjeta;
                 }
             }
@@ -122,5 +128,25 @@ class StandardCheckout
             "installments" => Configuration::get('MERCADOPAGO_INSTALLMENTS')
         );
         return $informations;
+    }
+
+    /**
+     * Payment Methods check
+     *
+     * @param mixed $tarjeta
+     * @return int
+     */
+    private function paymentMethodsCheck($tarjeta){
+        if (strtolower($tarjeta['id']) != 'meliplace' && $tarjeta['type'] != 'account_money') {
+            if ($tarjeta['type'] == 'credit_card') {
+                return self::METHOD_CREDIT_CARD;
+            } 
+            if ($tarjeta['type'] == 'debit_card' || $tarjeta['type'] == 'prepaid_card') {
+                return self::METHOD_DEBIT_CARD;
+            }
+            else {
+                return self::METHOD_TICKET;
+            }
+        }
     }
 }

--- a/includes/module/checkouts/TicketCheckout.php
+++ b/includes/module/checkouts/TicketCheckout.php
@@ -83,10 +83,9 @@ class TicketCheckout
         $ticket = array();
         $tarjetas = $this->payment->mercadopago->getPaymentMethods();
         foreach ($tarjetas as $tarjeta) {
-            if (Configuration::get('MERCADOPAGO_TICKET_PAYMENT_' . $tarjeta['id']) != "") {
-                if ($tarjeta['type'] != 'credit_card'
-                    && $tarjeta['type'] != 'debit_card'
-                    && $tarjeta['type'] != 'prepaid_card'
+            if (Configuration::get('MERCADOPAGO_TICKET_PAYMENT_' . $tarjeta['id']) != "") {   
+                if ($tarjeta['type'] == 'ticket' &&
+                     strtolower($tarjeta['id']) != 'meliplace'
                 ) {
                     $ticket[] = $tarjeta;
                 }

--- a/includes/module/preference/StandardPreference.php
+++ b/includes/module/preference/StandardPreference.php
@@ -113,6 +113,8 @@ class StandardPreference extends AbstractPreference
         $excluded_payment_methods = array();
         $payment_methods = $this->mercadopago->getPaymentMethods();
 
+        Configuration::updateValue('MERCADOPAGO_PAYMENT_ACCOUNT_MONEY', 'on');
+
         foreach ($payment_methods as $payment_method) {
             $pm_variable_name = 'MERCADOPAGO_PAYMENT_' . Tools::strtoupper($payment_method['id']);
             $value = Configuration::get($pm_variable_name);

--- a/includes/module/settings/StandardSettings.php
+++ b/includes/module/settings/StandardSettings.php
@@ -253,7 +253,9 @@ class StandardSettings extends AbstractSettings
                     'id' => $pm_id,
                     'name' => $payment_method['name'],
                 );
-            } else {
+            } elseif($payment_method['type'] != 'account_money' &&
+                strtolower($payment_method['id']) != 'meliplace'
+            ){
                 $this->offline_payments[] = array(
                     'id' => $pm_id,
                     'name' => $payment_method['name'],

--- a/includes/module/settings/StandardSettings.php
+++ b/includes/module/settings/StandardSettings.php
@@ -224,7 +224,7 @@ class StandardSettings extends AbstractSettings
         MPLog::generate('Standard checkout configuration saved successfully');
     }
 
-     /**
+    /**
      * Set values for the form inputs
      *
      * @return array
@@ -313,7 +313,7 @@ class StandardSettings extends AbstractSettings
 
         return true;
         }
-        
+
     return false;
     }
 }

--- a/includes/module/settings/StandardSettings.php
+++ b/includes/module/settings/StandardSettings.php
@@ -224,7 +224,7 @@ class StandardSettings extends AbstractSettings
         MPLog::generate('Standard checkout configuration saved successfully');
     }
 
-    /**
+     /**
      * Set values for the form inputs
      *
      * @return array
@@ -245,22 +245,21 @@ class StandardSettings extends AbstractSettings
             $pm_id = $payment_method['id'];
             $pm_name = 'MERCADOPAGO_PAYMENT_' . $pm_id;
 
-            if ($payment_method['type'] == 'credit_card' ||
-                $payment_method['type'] == 'debit_card' ||
-                $payment_method['type'] == 'prepaid_card'
+            if ($this->onlinePaymentMethodsCheck($payment_method)
             ) {
                 $this->online_payments[] = array(
                     'id' => $pm_id,
                     'name' => $payment_method['name'],
                 );
-            } elseif($payment_method['type'] != 'account_money' &&
-                strtolower($payment_method['id']) != 'meliplace'
-            ){
+            } 
+            if(!$this->onlinePaymentMethodsCheck($payment_method) && 
+                $this->offlineExcludedPaymentMethodsCheck($payment_method)
+            ) {
                 $this->offline_payments[] = array(
-                    'id' => $pm_id,
-                    'name' => $payment_method['name'],
-                );
-            }
+                'id' => $pm_id,
+                'name' => $payment_method['name'],
+            );            
+        }
 
             $form_values[$pm_name] = Configuration::get($pm_name);
         }
@@ -282,5 +281,39 @@ class StandardSettings extends AbstractSettings
         }
 
         return $installments;
+    }
+
+    /**
+     * Online Payment Methods Check
+     *
+     * @param mixed $payment_method
+     * @return boolean
+     */
+    private function onlinePaymentMethodsCheck($payment_method){
+        if ($payment_method['type'] == 'credit_card' ||
+        $payment_method['type'] == 'debit_card' ||
+        $payment_method['type'] == 'prepaid_card'
+    ) {
+
+        return true; 
+    }
+
+    return false;
+    }
+
+    /**
+     * Offline Excluded Payment Methods Check
+     *
+     * @param mixed $payment_method
+     * @return boolean
+     */
+    private function offlineExcludedPaymentMethodsCheck($payment_method){
+    if($payment_method['type'] != 'account_money' &&
+        strtolower($payment_method['id']) != 'meliplace') { 
+
+        return true;
+        }
+        
+    return false;
     }
 }

--- a/includes/module/settings/TicketSettings.php
+++ b/includes/module/settings/TicketSettings.php
@@ -172,9 +172,8 @@ class TicketSettings extends AbstractSettings
 
         $payment_methods = $this->mercadopago->getPaymentMethods();
         foreach ($payment_methods as $payment_method) {
-            if ($payment_method['type'] != 'credit_card' &&
-                $payment_method['type'] != 'debit_card' &&
-                $payment_method['type'] != 'prepaid_card' &&
+            if ($payment_method['type'] == 'ticket' && 
+                strtolower($payment_method['id']) != 'meliplace' &&
                 !in_array($payment_method['id'], $this->getTicketExcludedMethods())
             ) {
                 $pm_id = $payment_method['id'];


### PR DESCRIPTION
Alterei a condição de exibição de meios de pagamento do tipo ticket, para os quais não temos suporte no Prestashop, e fiz o mesmo para a exibição desses meios no painel de configurações do seller.

<img width="748" alt="checkout - antes da mudança" src="https://user-images.githubusercontent.com/80361051/128422180-88e18d0c-5930-4356-893a-e95cfa773e6b.png">
<img width="755" alt="checkout - atual" src="https://user-images.githubusercontent.com/80361051/128422196-741c59ca-0f2a-4410-ac46-46fb85c1d42e.png">
<img width="882" alt="painel - antes da mudança" src="https://user-images.githubusercontent.com/80361051/128422201-ece6b007-9892-4a33-a937-528264f29796.png">
<img width="1152" alt="painel - atual" src="https://user-images.githubusercontent.com/80361051/128422206-8dbc6882-f762-43ff-8516-c5870dc2e336.png">
