### PR TITLE
fix(paycash): 🐛 set to display atm payment_methods on ticket gateway

### DIFF
--- a/includes/module/checkouts/TicketCheckout.php
+++ b/includes/module/checkouts/TicketCheckout.php
@@ -29,6 +29,8 @@
 
 class TicketCheckout
 {
+    const ALLOW_PAYMENT_METHOD_TYPES = ['ticket', 'atm'];
+
     /**
      * @var Mercadopago
      */
@@ -81,13 +83,13 @@ class TicketCheckout
     {
         $this->getTicketJS();
         $ticket = array();
-        $tarjetas = $this->payment->mercadopago->getPaymentMethods();
-        foreach ($tarjetas as $tarjeta) {
-            if (Configuration::get('MERCADOPAGO_TICKET_PAYMENT_' . $tarjeta['id']) != "") {
-                if ($tarjeta['type'] == 'ticket' &&
-                     Tools::strtolower($tarjeta['id']) != 'meliplace'
+        $paymentMethods = $this->payment->mercadopago->getPaymentMethods();
+        foreach ($paymentMethods as $paymentMethod) {
+            if (Configuration::get('MERCADOPAGO_TICKET_PAYMENT_' . $paymentMethod['id']) != "") {
+                if (in_array($paymentMethod['type'], self::ALLOW_PAYMENT_METHOD_TYPES) &&
+                     Tools::strtolower($paymentMethod['id']) != 'meliplace'
                 ) {
-                    $ticket[] = $tarjeta;
+                    $ticket[] = $paymentMethod;
                 }
             }
         }

--- a/includes/module/settings/TicketSettings.php
+++ b/includes/module/settings/TicketSettings.php
@@ -172,7 +172,7 @@ class TicketSettings extends AbstractSettings
 
         $payment_methods = $this->mercadopago->getPaymentMethods();
         foreach ($payment_methods as $payment_method) {
-            if ($payment_method['type'] == 'ticket'
+            if (in_array($payment_method['type'], TicketCheckout::ALLOW_PAYMENT_METHOD_TYPES)
                 && Tools::strtolower($payment_method['id']) != 'meliplace'
                 && !in_array($payment_method['id'], $this->getTicketExcludedMethods())
             ) {


### PR DESCRIPTION
Só um ajuste para mostrar os pagamentos do tipo atm do méxico no gateway de ticket.

![image](https://user-images.githubusercontent.com/1247740/133446951-ef5fc170-7bc1-4ec4-a1ae-5facecc4594d.png)
![image](https://user-images.githubusercontent.com/1247740/133447025-585fd768-6036-48f4-b003-c8b82648347e.png)

## fechando um pedido
![image](https://user-images.githubusercontent.com/1247740/133447512-3c87407f-3276-468a-9fa5-d2722ede8070.png)

