### PR TITLE
Changed get address methods to check if invoice and shipment addresses are different or the same

### DIFF
--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -333,11 +333,6 @@ class AbstractPreference
                 'street_name' => $this->build_street_name($address_invoice),
                 'street_number' => '-',
             ),
-            "user" => array(
-                "user_email" => $customer_fields['email'],
-                "user_registration_date" => $customer_fields['date_add'],
-                "registered_user" => "yes",
-              ),
         );
 
         return $customer_data;

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -330,10 +330,7 @@ class AbstractPreference
             ),
             'address' => array(
                 'zip_code' => $address_invoice->postcode,
-                'street_name' => $address_invoice->address1 . ' - ' .
-                    $address_invoice->address2 . ' - ' .
-                    $address_invoice->city . ' - ' .
-                    $address_invoice->country,
+                'street_name' => $this->build_street_name($address_invoice),
                 'street_number' => '-',
             ),
             "user" => array(
@@ -358,10 +355,7 @@ class AbstractPreference
         $shipment = array(
             'receiver_address' => array(
                 'zip_code' => $address_shipment->postcode,
-                'street_name' => $address_shipment->address1 . ' - ' .
-                    $address_shipment->address2 . ' - ' .
-                    $address_shipment->city . ' - ' .
-                    $address_shipment->country,
+                'street_name' => $this->build_street_name($address_shipment),
                 'street_number' => '-',
                 'apartment' => '-',
                 'floor' => '-',
@@ -417,8 +411,7 @@ class AbstractPreference
             "seller_website"=> Tools::getShopDomainSsl(true, true),
             "billing_address" => array(
                 'zip_code' => $address_invoice->postcode,
-                'street_name' => $address_invoice->address1 . ' - ' .
-                    $address_invoice->address2,
+                'street_name' => $address_invoice->address1 . ' - ' . $address_invoice->address2,
                 'street_number' => '-',
                 'city_name'=> $address_invoice->city,
                 'country_name' => $address_invoice->country,
@@ -692,5 +685,21 @@ class AbstractPreference
 
         $encodedLogs = Tools::jsonEncode($logs);
         MPLog::generate($checkout . ' preference logs: ' . $encodedLogs);
+    }
+
+    /**
+     * build street name
+     *
+     * @param object $address_data
+     * @return string
+     */
+    function build_street_name($address_data)
+    {
+        $address = $address_data->address1 . ' - ' .
+        $address_data->address2 . ' - ' .
+        $address_data->city . ' - ' .
+        $address_data->country;
+
+        return $address;
     }
 }

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -348,8 +348,7 @@ class AbstractPreference
      */
     public function getShipmentAddress($cart)
     {
-        $address_shipment = null;
-        ($this->use_same_address)? $address_shipment = new Address((int) $cart->id_address_invoice) : $address_shipment = new Address((int) $cart->id_address_delivery);
+        $address_shipment = ($this->use_same_address) ? new Address((int) $cart->id_address_invoice) : new Address((int) $cart->id_address_delivery);
 
         $shipment = array(
             'receiver_address' => array(

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -348,7 +348,7 @@ class AbstractPreference
      */
     public function getShipmentAddress($cart)
     {
-        $address_shipment = ($this->use_same_address) ? new Address((int) $cart->id_address_invoice) : new Address((int) $cart->id_address_delivery);
+        $address_shipment = new Address((int) $cart->id_address_delivery);
 
         $shipment = array(
             'receiver_address' => array(
@@ -408,14 +408,14 @@ class AbstractPreference
             "custom_settings" => $this->getCustomCheckoutSettings(),
             "ticket_settings" => $this->getTicketCheckoutSettings(),
             "seller_website"=> Tools::getShopDomainSsl(true, true),
-            'billing_address' => array(
-                  'zip_code' => $address_invoice->postcode,
-                  'street_name' => $address_invoice->address1 . ' - ' .
-                      $address_invoice->address2,          
-                  'street_number' => '-',
-                  'city_name'=> $address_invoice->city,
-                  'country_name' => $address_invoice->country,
-            )
+            "billing_address" => array(
+                'zip_code' => $address_invoice->postcode,
+                'street_name' => $address_invoice->address1 . ' - ' .
+                    $address_invoice->address2,          
+                'street_number' => '-',
+                'city_name'=> $address_invoice->city,
+                'country_name' => $address_invoice->country,
+            ),
         );
 
         return $internal_metadata;

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -330,7 +330,7 @@ class AbstractPreference
             ),
             'address' => array(
                 'zip_code' => $address_invoice->postcode,
-                'street_name' => $this->build_street_name($address_invoice),
+                'street_name' => $this->buildStreetName($address_invoice),
                 'street_number' => '-',
             ),
         );
@@ -350,7 +350,7 @@ class AbstractPreference
         $shipment = array(
             'receiver_address' => array(
                 'zip_code' => $address_shipment->postcode,
-                'street_name' => $this->build_street_name($address_shipment),
+                'street_name' => $this->buildStreetName($address_shipment),
                 'street_number' => '-',
                 'apartment' => '-',
                 'floor' => '-',
@@ -412,9 +412,9 @@ class AbstractPreference
                 'country_name' => $address_invoice->country,
             ),
             "user" => array(
-            "registered_user" => (($is_logged) ? 'yes' : 'no'),
-            "user_email" => (($is_logged) ? $customer_fields['email'] : " "),
-            "user_registration_date" => (($is_logged) ? $customer_fields['date_add'] : " "),
+            "registered_user" => $is_logged ? 'yes' : 'no',
+            "user_email" => $is_logged ? $customer_fields['email'] : " ",
+            "user_registration_date" => $is_logged ? $customer_fields['date_add'] : " ",
           ),
         );
 
@@ -688,7 +688,7 @@ class AbstractPreference
      * @param object $address_data
      * @return string
      */
-    function build_street_name($address_data)
+    function buildStreetName($address_data)
     {
         $address = $address_data->address1 . ' - ' .
         $address_data->address2 . ' - ' .

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -360,6 +360,7 @@ class AbstractPreference
                 'street_number' => '-',
                 'apartment' => '-',
                 'floor' => '-',
+                'city_name' => $address_shipment->city,
             ),
         );
 

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -404,6 +404,7 @@ class AbstractPreference
             "basic_settings" => $this->getStandardCheckoutSettings(),
             "custom_settings" => $this->getCustomCheckoutSettings(),
             "ticket_settings" => $this->getTicketCheckoutSettings(),
+            "seller_website"=> Tools::getShopDomainSsl(true, true),
         );
 
         return $internal_metadata;

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -348,15 +348,16 @@ class AbstractPreference
      */
     public function getShipmentAddress($cart)
     {
-        $address_invoice = new Address((int) $cart->id_address_invoice);
+        $address_shipment = null;
+        ($this->use_same_address)? $address_shipment = new Address((int) $cart->id_address_invoice) : $address_shipment = new Address((int) $cart->id_address_delivery);
 
         $shipment = array(
             'receiver_address' => array(
-                'zip_code' => $address_invoice->postcode,
-                'street_name' => $address_invoice->address1 . ' - ' .
-                    $address_invoice->address2 . ' - ' .
-                    $address_invoice->city . ' - ' .
-                    $address_invoice->country,
+                'zip_code' => $address_shipment->postcode,
+                'street_name' => $address_shipment->address1 . ' - ' .
+                    $address_shipment->address2 . ' - ' .
+                    $address_shipment->city . ' - ' .
+                    $address_shipment->country,
                 'street_number' => '-',
                 'apartment' => '-',
                 'floor' => '-',

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -335,7 +335,12 @@ class AbstractPreference
                     $address_invoice->city . ' - ' .
                     $address_invoice->country,
                 'street_number' => '-',
-            )
+            ),
+            "user" => array(
+                "user_email" => $customer_fields['email'],
+                "user_registration_date" => $customer_fields['date_add'],
+                "registered_user" => "yes",
+              ),
         );
 
         return $customer_data;
@@ -394,6 +399,8 @@ class AbstractPreference
     public function getInternalMetadata($cart)
     {
         $address_invoice = new Address((int) $cart->id_address_invoice);
+        $customer_fields = Context::getContext()->customer->getFields();
+        $is_logged = Context::getContext()->customer->isLogged();
 
         $internal_metadata = array(
             "details" => "",
@@ -411,11 +418,16 @@ class AbstractPreference
             "billing_address" => array(
                 'zip_code' => $address_invoice->postcode,
                 'street_name' => $address_invoice->address1 . ' - ' .
-                    $address_invoice->address2,          
+                    $address_invoice->address2,
                 'street_number' => '-',
                 'city_name'=> $address_invoice->city,
                 'country_name' => $address_invoice->country,
             ),
+            "user" => array(
+            "registered_user" => (($is_logged) ? 'yes' : 'no'),
+            "user_email" => (($is_logged) ? $customer_fields['email'] : " "),
+            "user_registration_date" => (($is_logged) ? $customer_fields['date_add'] : " "),
+          ),
         );
 
         return $internal_metadata;

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -390,8 +390,10 @@ class AbstractPreference
      *
      * @return array
      */
-    public function getInternalMetadata()
+    public function getInternalMetadata($cart)
     {
+        $address_invoice = new Address((int) $cart->id_address_invoice);
+
         $internal_metadata = array(
             "details" => "",
             "platform" => MPRestCli::PLATFORM_ID,
@@ -405,6 +407,14 @@ class AbstractPreference
             "custom_settings" => $this->getCustomCheckoutSettings(),
             "ticket_settings" => $this->getTicketCheckoutSettings(),
             "seller_website"=> Tools::getShopDomainSsl(true, true),
+            'billing_address' => array(
+                  'zip_code' => $address_invoice->postcode,
+                  'street_name' => $address_invoice->address1 . ' - ' .
+                      $address_invoice->address2,          
+                  'street_number' => '-',
+                  'city_name'=> $address_invoice->city,
+                  'country_name' => $address_invoice->country,
+            )
         );
 
         return $internal_metadata;

--- a/includes/module/preference/CustomPreference.php
+++ b/includes/module/preference/CustomPreference.php
@@ -51,7 +51,7 @@ class CustomPreference extends AbstractPreference
         $preference['payer']['email'] = $this->getCustomerEmail();
         $preference['additional_info']['payer'] = $this->getCustomCustomerData($cart);
         $preference['additional_info']['shipments'] = $this->getShipmentAddress($cart);
-        $preference['metadata'] = $this->getInternalMetadata();
+        $preference['metadata'] = $this->getInternalMetadata($cart);
         $preference['token'] = $custom_info['card_token_id'];
         $preference['installments'] = (int) $custom_info['installments'];
         $preference['payment_method_id'] = $custom_info['payment_method_id'];
@@ -155,9 +155,9 @@ class CustomPreference extends AbstractPreference
      *
      * @return array
      */
-    public function getInternalMetadata()
+    public function getInternalMetadata($cart)
     {
-        $internal_metadata = parent::getInternalMetadata();
+        $internal_metadata = parent::getInternalMetadata($cart);
         $internal_metadata['checkout'] = 'custom';
         $internal_metadata['checkout_type'] = 'credit_card';
 

--- a/includes/module/preference/StandardPreference.php
+++ b/includes/module/preference/StandardPreference.php
@@ -54,7 +54,7 @@ class StandardPreference extends AbstractPreference
         $preference['binary_mode'] = $this->getBinaryMode();
         $preference['expires'] = $this->getExpirationStatus();
         $preference['expiration_date_to'] = $this->getExpirationDate();
-        $preference['metadata'] = $this->getInternalMetadata();
+        $preference['metadata'] = $this->getInternalMetadata($cart);
 
         //Generate preference
         $this->generateLogs($preference, $cart);
@@ -224,9 +224,9 @@ class StandardPreference extends AbstractPreference
      *
      * @return array
      */
-    public function getInternalMetadata()
+    public function getInternalMetadata($cart)
     {
-        $internal_metadata = parent::getInternalMetadata();
+        $internal_metadata = parent::getInternalMetadata($cart);
         $internal_metadata['checkout'] = 'smart';
         $internal_metadata['checkout_type'] = 'redirect';
 

--- a/includes/module/preference/StandardPreference.php
+++ b/includes/module/preference/StandardPreference.php
@@ -47,7 +47,7 @@ class StandardPreference extends AbstractPreference
         $preference = $this->getCommonPreference($cart);
         $preference['items'] = $this->getCartItems($cart);
         $preference['payer'] = $this->getCustomerData($cart);
-        $preference['shipments'] = $this->getShipment();
+        $preference['shipments'] = $this->getShipment($cart);
         $preference['back_urls'] = $this->getBackUrls($cart);
         $preference['payment_methods'] = $this->getPaymentOptions();
         $preference['auto_return'] = $this->getAutoReturn();
@@ -140,11 +140,25 @@ class StandardPreference extends AbstractPreference
      *
      * @return array
      */
-    public function getShipment()
+    public function getShipment($cart)
     {
-        return array(
-            'mode' => 'not_specified'
+        $address_shipment = new Address((int) $cart->id_address_delivery);
+
+        $shipment = array(
+            'receiver_address' => array(
+                'zip_code' => $address_shipment->postcode,
+                'street_name' => $address_shipment->address1 . ' - ' .
+                    $address_shipment->address2 . ' - ' .
+                    $address_shipment->city . ' - ' .
+                    $address_shipment->country,
+                'street_number' => '-',
+                'apartment' => '-',
+                'floor' => '-',
+                'city_name' => $address_shipment->city,
+            ),
         );
+
+        return $shipment;
     }
 
     /**

--- a/includes/module/preference/TicketPreference.php
+++ b/includes/module/preference/TicketPreference.php
@@ -54,7 +54,7 @@ class TicketPreference extends AbstractPreference
         $preference['description'] = $this->getPreferenceDescription($cart);
         $preference['payment_method_id'] = $ticket_info['paymentMethodId'];
         $preference['payer']['email'] = $this->getCustomerEmail();
-        $preference['metadata'] = $this->getInternalMetadata();
+        $preference['metadata'] = $this->getInternalMetadata($cart);
 
         if ($this->settings['MERCADOPAGO_SITE_ID'] == 'MLB') {
             $preference['payer']['first_name'] = $ticket_info['firstname'];
@@ -188,9 +188,9 @@ class TicketPreference extends AbstractPreference
      *
      * @return array
      */
-    public function getInternalMetadata()
+    public function getInternalMetadata($cart)
     {
-        $internal_metadata = parent::getInternalMetadata();
+        $internal_metadata = parent::getInternalMetadata($cart);
         $internal_metadata['checkout'] ='custom';
         $internal_metadata['checkout_type'] ='ticket';
 


### PR DESCRIPTION
- Alterei o método getShipmentAddress na classe AbstractPreference para capturar o endereço de shipment caso o cliente escolha um endereço diferente do endereço de faturação.
- Adicionei ao metadata o campo billing address com os sub campos de endereço.
- Adicionei ao metadata o campo user para receber dados logados de email e data de registro do cliente.
- Alterei os sub campos no campo shipments, passando city de forma separada
- Alterei o método getShipment na classe StandardPreference (checkout pro), para que passe a enviar os campos de shipment em vez do campo mode => 'not specified'.