### PR TITLE
Corrigido link de suporte para o espanhol - Release 4.10.0

### DIFF
--- a/views/templates/admin/template_1.tpl
+++ b/views/templates/admin/template_1.tpl
@@ -147,7 +147,7 @@
     <div class="tab-content">
         <div class="tab-pane active" id="standard_checkout">{html_entity_decode($standard_form|escape:'html':'UTF-8')}</div>
         <div class="tab-pane" id="custom_checkout">{html_entity_decode($custom_form|escape:'html':'UTF-8')}</div>
-        <div class="tab-pane" id="ticket_checkout">{html_entity_decode($ticket_form|escape:'html':'UTF-8')}</div> 
+        <div class="tab-pane" id="ticket_checkout">{html_entity_decode($ticket_form|escape:'html':'UTF-8')}</div>
         <div class="tab-pane" id="pix_checkout">{html_entity_decode($pix_form|escape:'html':'UTF-8')}</div>
     </div>
 
@@ -215,7 +215,7 @@
         {if $country_link == 'mlb'}
           <a href="https://www.mercadopago.com.br/developers/pt/support" target="_blank">{l s='Get in touch with our support.' mod='mercadopago'}</a>
         {else}
-          <a href="https://www.mercadopago.com.br/developers/es/support" target="_blank">{l s='Get in touch with our support.' mod='mercadopago'}</a>
+          <a href="https://www.mercadopago.com.ar/developers/es/support" target="_blank">{l s='Get in touch with our support.' mod='mercadopago'}</a>
         {/if}
     </div>
 </div>


### PR DESCRIPTION
- Corrigido link de suporte para o espanhol no fim da página do admin.

<img width="373" alt="Captura de Tela 2022-03-14 às 10 48 36" src="https://user-images.githubusercontent.com/61166244/158185360-7a9a12dc-1540-4b3d-82f9-975967fad148.png">

