### PR TITLE
Change/tools encode decode

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,34 @@
+## 📝 Description
+
+> A description of the PR, usually this description is the same as the JIRA story/task.
+> [#PSW-1234](jira.link.com)
+
+## 🎯 Goals
+
+> What and how the task were done.
+> If applicable, a list of:
+> - [ ] what need to do
+> - [x] what it is doing
+> - [x] and what was done
+
+## 📸 Screenshots
+
+> - Before and after, if is a fix
+> - New screens of new features
+> - Changes in all resolutions
+
+## 🧰 How to reproduce
+
+> - Step by step of how to test
+> - What scopes need to be activated
+> - External docs links
+
+<!--  Optional items
+## 🔗 Links
+> - [link1.com](https://)
+> - [link2.com](https://)
+
+## 🔀 Related PRs
+> - #123
+> - #321
+-->

--- a/controllers/front/standard.php
+++ b/controllers/front/standard.php
@@ -56,7 +56,7 @@ class MercadoPagoStandardModuleFrontController extends ModuleFrontController
                     $this->standardModalCheckout($preference);
                 }
 
-                Tools::redirectLink($createPreference['init_point']);
+                Tools::redirect($createPreference['init_point']);
             }
 
             $this->redirectError($preference, Tools::displayError());
@@ -115,7 +115,7 @@ class MercadoPagoStandardModuleFrontController extends ModuleFrontController
     {
         $backUrl = Tools::getValue('back_url');
         if (isset($backUrl)) {
-            Tools::redirectLink($backUrl);
+            Tools::redirect($backUrl);
         }
 
         $preference->redirectError();

--- a/controllers/front/standard.php
+++ b/controllers/front/standard.php
@@ -135,7 +135,7 @@ class MercadoPagoStandardModuleFrontController extends ModuleFrontController
             'preference' => $preference,
         );
 
-        echo Tools::jsonEncode($response);
+        echo json_encode($response);
         http_response_code($code);
         exit();
     }

--- a/controllers/front/standardvalidation.php
+++ b/controllers/front/standardvalidation.php
@@ -123,7 +123,7 @@ class MercadoPagoStandardValidationModuleFrontController extends ModuleFrontCont
         $url .= '&id_order=' . $order->id;
         $url .= '&id_module=' . $this->module->id;
 
-        return Tools::redirectLink($url);
+        return Tools::redirect($url);
     }
 
     /**

--- a/controllers/front/standardvalidation.php
+++ b/controllers/front/standardvalidation.php
@@ -51,21 +51,30 @@ class MercadoPagoStandardValidationModuleFrontController extends ModuleFrontCont
         $payment_ids = Tools::getValue('collection_id');
         $cartId = Tools::getValue('cart_id');
 
-
         if (isset($payment_ids) && $payment_ids != false && $payment_ids != 'null' && $typeReturn != 'failure') {
             $payment_id = explode(',', $payment_ids)[0];
             $this->redirectCheck($payment_id);
+            
             return;
         }
 
-        if (isset($cartId)) {
+        if (isset($cartId) && $typeReturn != 'failure') {
             $order = $this->mp_transaction->where('cart_id', '=', $cartId)->get();
-            $merchant = $this->mercadopago->getMerchantOrder($order['merchant_order_id']);
-            $payment_id = $merchant['payments'][0]['id'];
+            $merchant_order_id = $order['merchant_order_id'];
 
-            $this->redirectCheck($payment_id);
+            if ($merchant_order_id || $merchant_order_id === '0') {
+                $merchant_order = $this->mercadopago->getMerchantOrder($order['merchant_order_id']);
+                $payment_id = $merchant_order['payments'][0]['id'];
+
+                $this->redirectCheck($payment_id);
+            } else {
+                $this->redirectError();
+            }
+
             return;
         }
+
+        $this->redirectError();
     }
 
     /**
@@ -85,6 +94,7 @@ class MercadoPagoStandardValidationModuleFrontController extends ModuleFrontCont
 
             $this->redirectOrderConfirmation($cart, $order);
         }
+
         $this->redirectError();
     }
 

--- a/controllers/front/walletbutton.php
+++ b/controllers/front/walletbutton.php
@@ -78,7 +78,7 @@ class MercadoPagoWalletButtonModuleFrontController extends ModuleFrontController
             'preference' => $preference,
         );
 
-        echo Tools::jsonEncode($response);
+        echo json_encode($response);
         http_response_code($code);
         exit();
     }

--- a/includes/MPRestCli.php
+++ b/includes/MPRestCli.php
@@ -81,9 +81,9 @@ class MPRestCli
     {
         if ($content_type == 'application/json') {
             if (gettype($data) == 'string') {
-                Tools::jsonDecode($data, true);
+                json_decode($data, true);
             } else {
-                $data = Tools::jsonEncode($data);
+                $data = json_encode($data);
             }
 
             if (function_exists('json_last_error')) {
@@ -118,7 +118,7 @@ class MPRestCli
         $api_http_code = curl_getinfo($connect, CURLINFO_HTTP_CODE);
         $response = array(
             'status' => $api_http_code,
-            'response' => Tools::jsonDecode($api_result, true),
+            'response' => json_decode($api_result, true),
         );
 
         curl_close($connect);

--- a/includes/module/notification/AbstractNotification.php
+++ b/includes/module/notification/AbstractNotification.php
@@ -531,7 +531,7 @@ class AbstractNotification
             "version" => MP_VERSION
         );
 
-        echo Tools::jsonEncode($response);
+        echo json_encode($response);
         return http_response_code($code);
     }
 
@@ -570,7 +570,7 @@ class AbstractNotification
           "order_state" => $this->order_state,
         ];
 
-        $encodedLogs = Tools::jsonEncode($logs);
+        $encodedLogs = json_encode($logs);
         MPLog::generate('Order id ' . $this->order_id . ' notification logs: ' . $encodedLogs);
     }
 }

--- a/includes/module/preference/AbstractPreference.php
+++ b/includes/module/preference/AbstractPreference.php
@@ -699,7 +699,7 @@ abstract class AbstractPreference
             "metadata" => array_diff_key($preference['metadata'], array_flip(['collector'])),
         ];
 
-        $encodedLogs = Tools::jsonEncode($logs);
+        $encodedLogs = json_encode($logs);
         MPLog::generate($checkout . ' preference logs: ' . $encodedLogs);
     }
 

--- a/includes/module/preference/CustomPreference.php
+++ b/includes/module/preference/CustomPreference.php
@@ -72,7 +72,7 @@ class CustomPreference extends AbstractPreference
 
         //Generate preference
         $this->generateLogs($preference, 'custom');
-        $preferenceEncoded = Tools::jsonEncode($preference);
+        $preferenceEncoded = json_encode($preference);
 
         //Create preference
         $createPreference = $this->mercadopago->createPayment($preferenceEncoded);

--- a/includes/module/preference/PixPreference.php
+++ b/includes/module/preference/PixPreference.php
@@ -53,7 +53,7 @@ class PixPreference extends AbstractPreference
         $payload['transaction_amount'] = $this->getAmount();
 
         $this->generateLogs($payload, 'pix');
-        $payloadToJson = Tools::jsonEncode($payload);
+        $payloadToJson = json_encode($payload);
 
         $createPreference = $this->mercadopago->createPayment($payloadToJson);
         MPLog::generate('Cart ID ' . $this->cart->id . ' - Pix Preference created successfully');

--- a/includes/module/preference/StandardPreference.php
+++ b/includes/module/preference/StandardPreference.php
@@ -48,7 +48,7 @@ class StandardPreference extends AbstractStandardPreference
         $payload = $this->buildPreferencePayload($cart);
 
         $this->generateLogs($payload, $cart);
-        $payloadToJson = Tools::jsonEncode($payload);
+        $payloadToJson = json_encode($payload);
 
         $createPreference = $this->mercadopago->createPreference($payloadToJson);
         MPLog::generate('Cart id ' . $cart->id . ' - Standard Preference created successfully');
@@ -82,7 +82,7 @@ class StandardPreference extends AbstractStandardPreference
     public function getInternalMetadata($cart)
     {
         $internalMetadataParent = parent::getInternalMetadata($cart);
-        
+
         $checkoutType = $this->settings['MERCADOPAGO_STANDARD_MODAL'] ? 'modal' : 'redirect';
 
         $internalMetadataAdditional = array(
@@ -109,7 +109,7 @@ class StandardPreference extends AbstractStandardPreference
             "metadata" => array_diff_key($preference['metadata'], array_flip(['collector'])),
         );
 
-        $encodedLogs = Tools::jsonEncode($logs);
+        $encodedLogs = json_encode($logs);
         MPLog::generate('standard preference logs: ' . $encodedLogs);
     }
 }

--- a/includes/module/preference/TicketPreference.php
+++ b/includes/module/preference/TicketPreference.php
@@ -106,7 +106,7 @@ class TicketPreference extends AbstractPreference
 
         //Generate preference
         $this->generateLogs($preference, 'ticket');
-        $preferenceEncoded = Tools::jsonEncode($preference);
+        $preferenceEncoded = json_encode($preference);
 
         //Create preference
         $createPreference = $this->mercadopago->createPayment($preferenceEncoded);

--- a/includes/module/preference/WalletButtonPreference.php
+++ b/includes/module/preference/WalletButtonPreference.php
@@ -48,7 +48,7 @@ class WalletButtonPreference extends AbstractStandardPreference
         $payload = $this->buildPreferencePayload($cart, Configuration::get('MERCADOPAGO_CUSTOM_DISCOUNT'));
 
         $this->generateLogs($payload, $cart);
-        $payloadToJson = Tools::jsonEncode($payload);
+        $payloadToJson = json_encode($payload);
 
         $createPreference = $this->mercadopago->createPreference($payloadToJson);
         MPLog::generate('Cart id ' . $cart->id . ' - Wallet Button Preference created successfully');
@@ -146,7 +146,7 @@ class WalletButtonPreference extends AbstractStandardPreference
             "metadata" => array_diff_key($preference['metadata'], array_flip(['collector'])),
         );
 
-        $encodedLogs = Tools::jsonEncode($logs);
+        $encodedLogs = json_encode($logs);
         MPLog::generate('wallet button preference logs: ' . $encodedLogs);
     }
 }


### PR DESCRIPTION
## 📝 Description

> Changes to make compatibility to Prestashop v8 and php 8.1
> [#PSW-409](https://mercadolibre.atlassian.net/browse/PSW-409)

## 🎯 Goals

> Changed Tools::jsonEncode/Tools::jsonDecode to native json_encode/json_decode function
> Updated function Tools::redirectLink to Tools::redirect
> Added validation for when merchant_order_id is null, empty or invalid for PSE scenarios

## 🧰 How to reproduce

> - Build a test store for Prestashop version 6, 7 or 8
> - Install this mercadopago plugin version
> - Setup store and make test purchases with different payment methods

<!--  Optional items
## 🔗 Links
> - [link1.com](https://mercadolibre.atlassian.net/wiki/spaces/PLU/pages/1843594142/Docker+para+desenvolvimento)
