### PR TITLE
Feature/psw 439/listado de meios de pago

### DIFF
--- a/includes/MPApi.php
+++ b/includes/MPApi.php
@@ -111,8 +111,10 @@ class MPApi
      */
     public function getPaymentMethods()
     {
-        $access_token = $this->getAccessToken();
-        $response = MPRestCli::get('/v1/payment_methods', ["Authorization: Bearer " . $access_token]);
+        $public_key = $this->getPublicKey();
+        $response = MPRestCli::get('/v1/bifrost/payment-methods', ["Authorization: " . $public_key]);
+
+
 
         //in case of failures
         if ($response['status'] > 202) {
@@ -124,6 +126,11 @@ class MPApi
         $result = $response['response'];
         asort($result);
 
+
+        // echo('<pre>');
+        // print_r($result);
+        // die();
+
         $payments = array();
         foreach ($result as $value) {
             // remove on paypay release
@@ -133,9 +140,9 @@ class MPApi
 
             // PayCash
             if ($value['id'] == 'paycash') {
-                if (!isset($value['payment_places'])) {
+                if (isset($value['payment_places'])) {
                     $payments[] = array(
-                    'payment_places' => $this->getPaymentPlaces($value['id']),
+                    'payment_places' => $value['payment_places'],
                     'id' => Tools::strtoupper($value['id']),
                     'name' => $value['name'],
                     'type' => $value['payment_type_id'],
@@ -366,47 +373,47 @@ class MPApi
         }
     }
 
-  /**
-   * @param string|null $message
-   * @return string|null
-   */
-    public static function getPaymentPlaces($paymentId)
-    {
-        $payment_places = [
-            'paycash' => [
-                [
-                    "payment_option_id" => "7eleven",
-                    "name"              => "7 Eleven",
-                    "status"            => "active",
-                    "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/417ddb90-34ab-11e9-b8b8-15cad73057aa-s.png"
-                ],
-                [
-                    "payment_option_id" => "circlek",
-                    "name"              => "Circle K",
-                    "status"            => "active",
-                    "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/6f952c90-34ab-11e9-8357-f13e9b392369-s.png"
-                ],
-                [
-                    "payment_option_id" => "soriana",
-                    "name"              => "Soriana",
-                    "status"            => "active",
-                    "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/dac0bf10-01eb-11ec-ad92-052532916206-s.png"
-                ],
-                [
-                    "payment_option_id" => "extra",
-                    "name"              => "Extra",
-                    "status"            => "active",
-                    "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/9c8f26b0-34ab-11e9-b8b8-15cad73057aa-s.png"
-                ],
-                [
-                    "payment_option_id" => "calimax",
-                    "name"              => "Calimax",
-                    "status"            => "active",
-                    "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/52efa730-01ec-11ec-ba6b-c5f27048193b-s.png"
-                ]
-            ],
-        ];
+//   /**
+//    * @param string|null $message
+//    * @return string|null
+//    */
+//     public static function getPaymentPlaces($paymentId)
+//     {
+//         $payment_places = [
+//             'paycash' => [
+//                 [
+//                     "payment_option_id" => "7eleven",
+//                     "name"              => "7 Eleven",
+//                     "status"            => "active",
+//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/417ddb90-34ab-11e9-b8b8-15cad73057aa-s.png"
+//                 ],
+//                 [
+//                     "payment_option_id" => "circlek",
+//                     "name"              => "Circle K",
+//                     "status"            => "active",
+//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/6f952c90-34ab-11e9-8357-f13e9b392369-s.png"
+//                 ],
+//                 [
+//                     "payment_option_id" => "soriana",
+//                     "name"              => "Soriana",
+//                     "status"            => "active",
+//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/dac0bf10-01eb-11ec-ad92-052532916206-s.png"
+//                 ],
+//                 [
+//                     "payment_option_id" => "extra",
+//                     "name"              => "Extra",
+//                     "status"            => "active",
+//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/9c8f26b0-34ab-11e9-b8b8-15cad73057aa-s.png"
+//                 ],
+//                 [
+//                     "payment_option_id" => "calimax",
+//                     "name"              => "Calimax",
+//                     "status"            => "active",
+//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/52efa730-01ec-11ec-ba6b-c5f27048193b-s.png"
+//                 ]
+//             ],
+//         ];
 
-        return $payment_places[$paymentId];
-    }
+//         return $payment_places[$paymentId];
+//     }
 }

--- a/includes/MPApi.php
+++ b/includes/MPApi.php
@@ -372,48 +372,4 @@ class MPApi
                 return null;
         }
     }
-
-//   /**
-//    * @param string|null $message
-//    * @return string|null
-//    */
-//     public static function getPaymentPlaces($paymentId)
-//     {
-//         $payment_places = [
-//             'paycash' => [
-//                 [
-//                     "payment_option_id" => "7eleven",
-//                     "name"              => "7 Eleven",
-//                     "status"            => "active",
-//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/417ddb90-34ab-11e9-b8b8-15cad73057aa-s.png"
-//                 ],
-//                 [
-//                     "payment_option_id" => "circlek",
-//                     "name"              => "Circle K",
-//                     "status"            => "active",
-//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/6f952c90-34ab-11e9-8357-f13e9b392369-s.png"
-//                 ],
-//                 [
-//                     "payment_option_id" => "soriana",
-//                     "name"              => "Soriana",
-//                     "status"            => "active",
-//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/dac0bf10-01eb-11ec-ad92-052532916206-s.png"
-//                 ],
-//                 [
-//                     "payment_option_id" => "extra",
-//                     "name"              => "Extra",
-//                     "status"            => "active",
-//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/9c8f26b0-34ab-11e9-b8b8-15cad73057aa-s.png"
-//                 ],
-//                 [
-//                     "payment_option_id" => "calimax",
-//                     "name"              => "Calimax",
-//                     "status"            => "active",
-//                     "thumbnail"         => "https://http2.mlstatic.com/storage/logos-api-admin/52efa730-01ec-11ec-ba6b-c5f27048193b-s.png"
-//                 ]
-//             ],
-//         ];
-
-//         return $payment_places[$paymentId];
-//     }
 }

--- a/includes/MPApi.php
+++ b/includes/MPApi.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * 2007-2022 PrestaShop
  *
@@ -127,10 +128,6 @@ class MPApi
         asort($result);
 
 
-        // echo('<pre>');
-        // print_r($result);
-        // die();
-
         $payments = array();
         foreach ($result as $value) {
             // remove on paypay release
@@ -141,30 +138,36 @@ class MPApi
             // PayCash
             if ($value['id'] == 'paycash') {
                 if (isset($value['payment_places'])) {
-                    $payments[] = array(
-                    'payment_places' => $value['payment_places'],
-                    'id' => Tools::strtoupper($value['id']),
-                    'name' => $value['name'],
-                    'type' => $value['payment_type_id'],
-                    'image' => $value['secure_thumbnail'],
-                    'config' => 'MERCADOPAGO_PAYMENT_' . Tools::strtoupper($value['id']),
-                    'financial_institutions' => $value['financial_institutions'],
-                    );
+                    $paymentsDefaultData = $this->paymentsDefaultData($value);
+                    $paymentPlaces = array('payment_places'=>$value['payment_places']);
+                    $payments[] = array_merge($paymentsDefaultData, $paymentPlaces);
+
                     continue;
                 }
             }
 
-            $payments[] = array(
-                'id' => Tools::strtoupper($value['id']),
-                'name' => $value['name'],
-                'type' => $value['payment_type_id'],
-                'image' => $value['secure_thumbnail'],
-                'config' => 'MERCADOPAGO_PAYMENT_' . Tools::strtoupper($value['id']),
-                'financial_institutions' => $value['financial_institutions'],
-            );
+            $payments[] = $this->paymentsDefaultData($value);
         }
 
         return $payments;
+    }
+
+    /**
+    * Get payment main data
+    *
+    * @param array $value
+    * @return array
+    */
+    public function paymentsDefaultData($value)
+    {
+        return array(
+            'id' => Tools::strtoupper($value['id']),
+            'name' => $value['name'],
+            'type' => $value['payment_type_id'],
+            'image' => $value['secure_thumbnail'],
+            'config' => 'MERCADOPAGO_PAYMENT_' . Tools::strtoupper($value['id']),
+            'financial_institutions' => $value['financial_institutions'],
+        );
     }
 
     /**

--- a/includes/MPApi.php
+++ b/includes/MPApi.php
@@ -135,15 +135,12 @@ class MPApi
                 continue;
             }
 
-            // PayCash
-            if ($value['id'] == 'paycash') {
-                if (isset($value['payment_places'])) {
-                    $paymentsDefaultData = $this->paymentsDefaultData($value);
-                    $paymentPlaces = array('payment_places'=>$value['payment_places']);
-                    $payments[] = array_merge($paymentsDefaultData, $paymentPlaces);
+            if (isset($value['payment_places'])) {
+                $paymentsDefaultData = $this->paymentsDefaultData($value);
+                $paymentPlaces = array('payment_places'=>$value['payment_places']);
+                $payments[] = array_merge($paymentsDefaultData, $paymentPlaces);
 
-                    continue;
-                }
+                continue;
             }
 
             $payments[] = $this->paymentsDefaultData($value);

--- a/includes/MPRestCli.php
+++ b/includes/MPRestCli.php
@@ -53,7 +53,7 @@ class MPRestCli
             $product_id,
             'Accept: application/json',
             'Content-Type: application/json',
-            'x-platform-id:' . self::PLATFORM_ID,
+            'x-platform-id: TEST_PLATFORM' /*. self::PLATFORM_ID*/,
             'x-integrator-id:' . Configuration::get('MERCADOPAGO_INTEGRATOR_ID')
         ];
         is_array($headers) ? $headers = array_merge($headers_default, $headers): '';


### PR DESCRIPTION
## 📝 Description

## 🎯 Goals

> We have set the plugin to get all payment methods from bifrost API instead of Mercado Pago API.

> - [ ] PLATFORM_ID still needs to be defined
> - [x] We have removed the function used as a mock to get the payment places related to paycash, and also refactored the function responsible for checking when payment type is paycash and adding the key payment_places to the array.
> - [x] The endpoint used now is '/v1/bifrost/payment-methods' opposed to the endpoint used before that was '/v1/payment-methods'

## 🧰 How to reproduce

> - You just need to install he MercadoPago plugin for PrestaShop, configure it and activate the checkouts of your preference to be shown on the checkout page
